### PR TITLE
Entferne Referenz auf veraltete CSS-Datei

### DIFF
--- a/2019/agb.php
+++ b/2019/agb.php
@@ -11,7 +11,6 @@
 
 	<link rel="stylesheet" href="./css/normalize.css">
 	<link rel="stylesheet" href="./css/base.css">
-	<link rel="stylesheet" href="./css/components.css">
 	<link rel="stylesheet" href="./css/print.css" media="print">
 </head>
 

--- a/2019/anmeldung/index.php
+++ b/2019/anmeldung/index.php
@@ -15,7 +15,6 @@
 	<link rel="stylesheet" href="./css/normalize.css">
 	<link rel="stylesheet" type="text/css" href="https://pretix.eu/fossgis/2019/widget/v1.css">
 	<link rel="stylesheet" href="./css/base.css">
-	<link rel="stylesheet" href="./css/components.css">
 	<link rel="stylesheet" href="./css/print.css" media="print">
 	<script type="text/javascript" src="https://pretix.eu/widget/v1.de.js" async></script>
 </head>

--- a/2019/anreise/index.php
+++ b/2019/anreise/index.php
@@ -13,7 +13,6 @@
 
 	<link rel="stylesheet" href="./css/normalize.css">
 	<link rel="stylesheet" href="./css/base.css">
-	<link rel="stylesheet" href="./css/components.css">
 	<link rel="stylesheet" href="./css/print.css" media="print">
 
 	<link rel="stylesheet" href="../static/leaflet/1.3.4/leaflet.css"/>

--- a/2019/loc/loc.php
+++ b/2019/loc/loc.php
@@ -13,7 +13,6 @@
 
 	<link rel="stylesheet" href="./css/normalize.css">
 	<link rel="stylesheet" href="./css/base.css">
-	<link rel="stylesheet" href="./css/components.css">
 </head>
 
 <body id="team">

--- a/2019/programm/index.php
+++ b/2019/programm/index.php
@@ -13,7 +13,6 @@
 
 	<link rel="stylesheet" href="./css/normalize.css">
 	<link rel="stylesheet" href="./css/base.css">
-	<link rel="stylesheet" href="./css/components.css">
 	<link rel="stylesheet" href="./css/print.css" media="print">
 </head>
 

--- a/2019/socialevents/index.php
+++ b/2019/socialevents/index.php
@@ -13,7 +13,6 @@
 
 	<link rel="stylesheet" href="./css/normalize.css">
 	<link rel="stylesheet" href="./css/base.css">
-	<link rel="stylesheet" href="./css/components.css">
 	<link rel="stylesheet" href="./css/print.css" media="print">
 </head>
 


### PR DESCRIPTION
Hatte sich noch eingeschlichen, die Datei gibt es so nicht mehr.