### PR TITLE
Pretix-Widget in Konferenz-Website integrieren

### DIFF
--- a/2019/anmeldung/index.php
+++ b/2019/anmeldung/index.php
@@ -26,29 +26,64 @@
 
 	<h2>Anmeldung zur Konferenz</h2>
 
-	<p class="highlight"><a href="https://pretix.eu/fossgis/2019/" target="_blank">Direkt zur Anmeldung &rarr;</a></p>
+	<p>
+		Wir laden Sie ein, Teil der FOSSGIS-Konferenz 2019 zu werden.
+		Die Konferenz lebt von Ihren Beitr&auml;gen und Ihrem Besuch.
+		Wir freuen uns auf Sie!
+	</p>
 
-	<p>Wir laden Sie ein, Teil der FOSSGIS-Konferenz 2019 zu werden. Die Konferenz lebt von Ihren Beitr&auml;gen und Ihrem Besuch. Wir freuen uns auf Sie!</p>
-	<p>Das Konferenz-Team empfielt Ihnen sich online anzumelden. Eine spontane Teilnahme kann aufgrund der räumlichen Begrenzung auf 400 Personen nicht gewährleistet werden. Eine Registrierung Ihrerseits ist notwendig, um Ihre Teilnahme zu sichern und hilfreich f&uuml;r die Organisation. </p>
+	<p>
+		Das Konferenz-Team empfielt Ihnen sich online anzumelden.
+		Eine spontane Teilnahme kann aufgrund der räumlichen Begrenzung auf 400 Personen nicht gewährleistet werden.
+		Eine Registrierung Ihrerseits ist notwendig, um Ihre Teilnahme zu sichern und hilfreich f&uuml;r die Organisation.
+	</p>
 
-	<p>Hier gelangen Sie <a href="https://pretix.eu/fossgis/2019/"> zur Anmeldung</a>. Im Rahmen der Anmeldung können Sie bis zum 11.03.2019 eine Reihe von FOSSGIS-Workshops (kostenpflichtig) auswählen. Informationen zu den einzelnen Workshops finden Sie im <a href="https://pretalx.com/fossgis2019/schedule/">Programm</a>. </p>
+	<p class="highlight">
+		&darr; <a href="#shop">Direkt zur Anmeldung</a>
+	</p>
 
-	<p class="highlight"><a href="https://pretix.eu/fossgis/2019/" target="_blank">Direkt zur Anmeldung &rarr;</a></p>
+	<p>
+		Im Rahmen der Anmeldung können Sie bis zum 11.03.2019 eine Reihe von FOSSGIS-Workshops (kostenpflichtig) auswählen.
+		Informationen zu den einzelnen Workshops finden Sie im <a href="https://pretalx.com/fossgis2019/schedule/">Programm</a>.
+	</p>
 
 	<h3>Preise FOSSGIS-Konferenz 2019</h3>
 	<ul>
 		<li>Standardticket (Normalpreis): € 190</li>
 		<li>Standardticket (Frühbucherrabatt bis 06.02.2019): € 150</li>
 		<li>Studierendenticket, Rentnerticket: € 40</li>
-		<li>Communityticket*: € 0*</li>
+		<li>Communityticket<sup>**</sup>: € 0</li>
 		<li>Workshop: € 100</li>
 		<li>Workshop (Frühbucherrabatt bis 06.02.2019): € 90</li>
 	</ul>
-	<p><b>Im Konferenzticket enthalten:</b> FOSSGIS-Konferenz-Teilnahme, Pausensnack, Tasche und wenn bestellt Tagungsband, T-Shirt und Abendveranstaltung Dialoge im Bärenzwinger.</p>
-	<p><small>* Regelungen für das Communityticket gelten für FOSSGIS-, OpenStreetMap- und OSGeo-Aktive sowie aktive Helfer der Konferenz.</small></p>
+	<p><b>Im Konferenzticket enthalten:</b></p>
+	<ul>
+		<li>FOSSGIS-Konferenz-Teilnahme</li>
+		<li>Pausensnack</li>
+		<li>Tasche, Tagungsband*</li>
+		<li>T-Shirt</li>
+		<li>Abendveranstaltung Dialoge im Bärenzwinger (solange verfügbar)</li>
+	</ul>
+
+	<p>
+		<small>* solange verfügbar</small><br>
+		<small>** Regelungen für das Communityticket gelten für FOSSGIS-, OpenStreetMap- und OSGeo-Aktive sowie aktive Helfer der Konferenz.</small>
+	</p>
 
 	<h3>Helfer</h3>
 	<p>Freiwillige Helfer sind eingeladen und willkommen während der Konferenz bei den Videoaufnahmen, als Sessionleiter oder beim Catering zu unterstützen. Bei Interesse bitte im <a href="https://helfer-2019.fossgis.de/">Helfersystem</a> Helfersystem anmelden und eine E-Mail an konferenz-orga@fossgis.de senden. Helfer dürfen das kostenfreie "Community-Ticket" buchen. Bei Fragen empfehlen wir die <a href="https://pretix.eu/fossgis/2019/page/helfer/" target="_blank">FAQ</a> zu lesen.</p>
+
+
+	<div id="shop">
+		<pretix-widget event="https://pretix.eu/fossgis/2019/"></pretix-widget>
+	</div>
+	<noscript>
+		<div class="pretix-widget">
+			<div class="pretix-widget-info-message">
+				JavaScript ist in Ihrem Browser deaktiviert. Um unseren Ticket-Shop ohne JavaScript aufzurufen, klicken Sie bitte <a target="_blank" rel="noopener" href="https://pretix.eu/fossgis/2019/">hier</a>.
+			</div>
+		</div>
+	</noscript>
 
 	<?php include('../inc/footer.inc'); ?>
 


### PR DESCRIPTION
Das Widget funktioniert lokal (http://) sehr gut, leitet beim Hinzufügen in den Warenkorb direkt auf die Pretix-Seite um. Auf der meiner [Testseite](https://www2.htw-dresden.de/~thurm/2019/anmeldung/) (https://) kann man den gesamten Kauf abschließen, wobei ich den Checkout jetzt nicht ausgeführt habe.