### PR TITLE
Direkter Link zum Ticketsystem ergänzt

### DIFF
--- a/2019/anmeldung/index.php
+++ b/2019/anmeldung/index.php
@@ -72,7 +72,8 @@
 	<h3>Helfer</h3>
 	<p>Freiwillige Helfer sind eingeladen und willkommen während der Konferenz bei den Videoaufnahmen, als Sessionleiter oder beim Catering zu unterstützen. Bei Interesse bitte im <a href="https://helfer-2019.fossgis.de/">Helfersystem</a> Helfersystem anmelden und eine E-Mail an konferenz-orga@fossgis.de senden. Helfer dürfen das kostenfreie "Community-Ticket" buchen. Bei Fragen empfehlen wir die <a href="https://pretix.eu/fossgis/2019/page/helfer/" target="_blank">FAQ</a> zu lesen.</p>
 
-
+	<h3>Anmeldung</h3>
+	<p>Nutzen Sie gerne das Anmeldeformular direkt auf dieser Seite. Falls etwas nicht funktionieren sollte, können Sie das Ticketsystem auch unter <a href="https://pretix.eu/fossgis/2019/">diesem Link</a> direkt aufrufen.</p>
 	<div id="shop">
 		<pretix-widget event="https://pretix.eu/fossgis/2019/"></pretix-widget>
 	</div>


### PR DESCRIPTION
Letztes Jahr hat das Ticketsystem nicht funktioniert, wenn Drittanbieter-Cookies deaktiviert waren. Deshalb habe ich sicherheitshalber wieder den Link zum Ticketsystem ergänzt.