### PR TITLE
IE quickfix for fluid header image

### DIFF
--- a/2019/css/base.css
+++ b/2019/css/base.css
@@ -28,8 +28,9 @@ figure {
 }
 
 .img-fluid {
-	max-width: 100%;
 	height: auto;
+	max-width: 100%;
+	width: 100%;
 }
 
 .page-header {


### PR DESCRIPTION
Das Titelbild hält sich im IE nicht an die definierte Breite des Seiteninhalts.