### PR TITLE
Browser-Cache bei Style-Änderungen zu Reload bewegen

### DIFF
--- a/2019/agb.php
+++ b/2019/agb.php
@@ -9,9 +9,7 @@
 	<meta name="keywords" content="FOSSGIS, FOSSGIS-Konferenz, 2019, FOSSGIS-Konferenz 2019, Open Source, GIS, Konferenz, Geoinformatik, OpenStreetMap, HTW Dresden">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-	<link rel="stylesheet" href="./css/normalize.css">
-	<link rel="stylesheet" href="./css/base.css">
-	<link rel="stylesheet" href="./css/print.css" media="print">
+	<?php include "../inc/style.inc"; ?>
 </head>
 
 <body id="home">

--- a/2019/anmeldung/index.php
+++ b/2019/anmeldung/index.php
@@ -12,10 +12,8 @@
 	<meta name="keywords" content="FOSSGIS, FOSSGIS-Konferenz, 2019, FOSSGIS-Konferenz 2019, Open Source, GIS, Konferenz, Geoinformatik, OpenStreetMap, HTW Dresden">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-	<link rel="stylesheet" href="./css/normalize.css">
 	<link rel="stylesheet" type="text/css" href="https://pretix.eu/fossgis/2019/widget/v1.css">
-	<link rel="stylesheet" href="./css/base.css">
-	<link rel="stylesheet" href="./css/print.css" media="print">
+	<?php include "../inc/style.inc"; ?>
 	<script type="text/javascript" src="https://pretix.eu/widget/v1.de.js" async></script>
 </head>
 

--- a/2019/anreise/index.php
+++ b/2019/anreise/index.php
@@ -11,9 +11,7 @@
 	<meta name="keywords" content="FOSSGIS, FOSSGIS-Konferenz, 2019, FOSSGIS-Konferenz 2019, Open Source, GIS, Konferenz, Geoinformatik, OpenStreetMap, HTW Dresden">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-	<link rel="stylesheet" href="./css/normalize.css">
-	<link rel="stylesheet" href="./css/base.css">
-	<link rel="stylesheet" href="./css/print.css" media="print">
+	<?php include "../inc/style.inc"; ?>
 
 	<link rel="stylesheet" href="../static/leaflet/1.3.4/leaflet.css"/>
 

--- a/2019/inc/style.inc
+++ b/2019/inc/style.inc
@@ -1,0 +1,4 @@
+<?php $version = 1; ?>
+<link rel="stylesheet" href="./css/normalize.css?version=<?php echo $version;?>">
+<link rel="stylesheet" href="./css/base.css?version=<?php echo $version;?>">
+<link rel="stylesheet" href="./css/print.css?version=<?php echo $version;?>" media="print">

--- a/2019/index.php
+++ b/2019/index.php
@@ -11,9 +11,7 @@
 	<meta name="keywords" content="FOSSGIS, FOSSGIS-Konferenz, 2019, FOSSGIS-Konferenz 2019, Open Source, GIS, Konferenz, Geoinformatik, OpenStreetMap, HTW Dresden">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-	<link rel="stylesheet" href="./css/normalize.css">
-	<link rel="stylesheet" href="./css/base.css">
-	<link rel="stylesheet" href="./css/print.css" media="print">
+	<?php include "inc/style.inc"; ?>
 </head>
 
 <body id="home">

--- a/2019/loc/loc.php
+++ b/2019/loc/loc.php
@@ -11,8 +11,7 @@
 	<meta name="keywords" content="FOSSGIS, FOSSGIS-Konferenz, 2019, FOSSGIS-Konferenz 2019, Open Source, GIS, Konferenz, Geoinformatik, OpenStreetMap, HTW Dresden">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-	<link rel="stylesheet" href="./css/normalize.css">
-	<link rel="stylesheet" href="./css/base.css">
+	<?php include "../inc/style.inc"; ?>
 </head>
 
 <body id="team">

--- a/2019/programm/index.php
+++ b/2019/programm/index.php
@@ -11,9 +11,7 @@
 	<meta name="keywords" content="FOSSGIS, FOSSGIS-Konferenz, 2019, FOSSGIS-Konferenz 2019, Open Source, GIS, Konferenz, Geoinformatik, OpenStreetMap, HTW Dresden">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-	<link rel="stylesheet" href="./css/normalize.css">
-	<link rel="stylesheet" href="./css/base.css">
-	<link rel="stylesheet" href="./css/print.css" media="print">
+	<?php include "../inc/style.inc"; ?>
 </head>
 
 <body id="programm">

--- a/2019/socialevents/index.php
+++ b/2019/socialevents/index.php
@@ -11,9 +11,7 @@
 	<meta name="keywords" content="FOSSGIS, FOSSGIS-Konferenz, 2019, FOSSGIS-Konferenz 2019, Open Source, GIS, Konferenz, Geoinformatik, OpenStreetMap, HTW Dresden">
 	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-	<link rel="stylesheet" href="./css/normalize.css">
-	<link rel="stylesheet" href="./css/base.css">
-	<link rel="stylesheet" href="./css/print.css" media="print">
+	<?php include "../inc/style.inc"; ?>
 </head>
 
 <body id="socialEvents">


### PR DESCRIPTION
Die Änderungen in #88 haben wohl hier und da zu ulkigen Ansichten auf der Teamseite geführt, bevor der Browser Cache geleert ist. Ich würde diese Änderung vorschlagen um eine einfache Möglichkeit zu bieten das in Zukunft kontrollieren zu können (und noch veraltete Caches jetzt zum Neuladen zu bewegen). Bei einer Änderung der CSS Dateien müsste lediglich die version inkrementiert werden. (Betrifft auch #87) 