### PR TITLE
Menüpunkte in Navigationsleiste besser verteilen und visuell abgrenzen

### DIFF
--- a/2019/css/base.css
+++ b/2019/css/base.css
@@ -64,15 +64,14 @@ nav .main {
 	flex-wrap: wrap;
 	-webkit-box-pack: center;
 	-ms-flex-pack: center;
-	justify-content: center;
+	justify-content: space-evenly;
 	list-style-type: none;
-	margin: 0;
+	margin: 10px 0 0;
 	padding: 0;
-	text-transform: uppercase;
 	border-bottom: 5px solid #eb7f00;
 }
 nav .main > li {
-	margin: 10px 20px 0;
+	padding: 5px 10px;
 }
 nav .main a {
 	text-decoration: none;


### PR DESCRIPTION
Die Änderung trennt die Menüpunkte durch natürliche Klein-/Großschreibung besser voneinander ab und verbessert das Umbrechen auf kleinen Bildschirmen.

Vorher:

![bildschirmfoto 2019-03-04 um 11 50 07](https://user-images.githubusercontent.com/1186959/53728741-b4fab080-3e73-11e9-92b5-df7121c64773.png)

Nachher:

![bildschirmfoto 2019-03-04 um 11 49 45](https://user-images.githubusercontent.com/1186959/53728757-bcba5500-3e73-11e9-8250-0f46d09fc8df.png)

Die PR ersetzt in Teilen #87. Die Änderungen dort beschrieben werde ich jetzt neu angehen um auch die Raumpläne mit auf die Website zu bringen.

