### PR TITLE
Link zum alten Buchungsformular entfernt

### DIFF
--- a/2020/index.php
+++ b/2020/index.php
@@ -181,7 +181,7 @@
 		</li>
 	</ul>
 
-	<p>Sie möchten die FOSSGIS-Konferenz als Sponsor unterstützen? Weitere Informationen für Sponsoren und Aussteller finden Sie <a href="http://www.fossgis.de/wiki/Sponsoren_und_Aussteller">hier</a>. Sie können das Sponsorenpaket bequem über unser <a href="https://pretix.eu/fossgis/2019/"> Buchungsformular</a> buchen.</p>
+	<p>Sie möchten die FOSSGIS-Konferenz als Sponsor unterstützen? Weitere Informationen für Sponsoren und Aussteller finden Sie <a href="http://www.fossgis.de/wiki/Sponsoren_und_Aussteller">hier</a>.</p>
 	<p>Bei Fragen wenden sie sich gerne an das <a href="mailto:konferenz-orga@fossgis.de">Konferenzorganisationsteam</a>.</p>
 
 	<?php include "inc/footer.inc"; ?>


### PR DESCRIPTION
Sponsoring wird dieses Jahr nicht mehr per Pretix verkauft.