### PR TITLE
Bessere Jitsi Links

### DIFF
--- a/2021/jitsi.html
+++ b/2021/jitsi.html
@@ -9,7 +9,9 @@ const JITSI_INSTANCE = 'https://meet.ffmuc.net'
 // The hash of the URLs has the following shape
 // <hash-bang><slash><type(speaker or regie)><slash><jitsi-room>
 // e.g.  #!/speaker/my-actual-jitsi-room
-const [type, room] = window.location.hash.substr(3).split('/')
+// The "bang" is optional, i.e. a URL like this is equal to the example above:
+// #/speaker/my-actual-jitsi-room
+const [_prefix, type, room] = window.location.hash.split('/')
 
 let parameters
 switch (type) {


### PR DESCRIPTION
Die Jitsi Links unterstützen jetzt auch URLs ohne Ausrufezeichen,
das funktioniert mit dem Chaospad besser. Es geht also anstatt

   #!/speaker/my-actual-jitsi-room

auch

   #/speaker/my-actual-jitsi-room