### PR TITLE
Move redirection to current konference to .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,1 +1,6 @@
 DirectoryIndex index.php
+
+# Aktuelle ausgabe der FOSSGIS Konferenz
+RewriteEngine on
+RewriteCond %{REQUEST_URI} ^/$
+RewriteRule (.*) /2024/ [R=307]


### PR DESCRIPTION
Hi,
es wäre schön wenn ihr das hier mergen könntet. 

Damit wird die konfiguration welches die aktuelle ausgabe der Konferenz Homepage ist in das .htaccess verlagert, und damit in die Hände der Content kreierenden gelegt. D.h. wir müssen nicht jedesmal den Webserver umkonfigurieren wenn die nächste Ausgabe ansteht.

Flo