### PR TITLE
Fix old konferenz pages

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,4 @@
-DirectoryIndex index.php
+DirectoryIndex index.php index.html
 
 # Aktuelle ausgabe der FOSSGIS Konferenz
 RewriteEngine on


### PR DESCRIPTION
Hi,
mir ist gerade so beim durchsehen aufgefallen das die Webseiten der Konferenzen 2011-13 nicht mehr gehen seit dem umzug auf die neue maschine.

Das liegt daran das die seiten noch keine PHP basierte erste Seite haben - damit haben die kein "index.php" sondern nur ein "index.html" das aber in der .htaccess nicht angegeben war.

Hier der Pull request das zu fixen. Dann gehen auch die rein html basierten seiten wieder.

Flo