### PR TITLE
Use preferred tile.openstreetmap.de URL

### DIFF
--- a/2026/standort/script/map.js
+++ b/2026/standort/script/map.js
@@ -26,7 +26,7 @@
 		className: 'svg-feature'
 	};
 
-	const baseLayer = L.tileLayer('https://{s}.tile.openstreetmap.de/{z}/{x}/{y}.png', {
+	const baseLayer = L.tileLayer('https://tile.openstreetmap.de/{z}/{x}/{y}.png', {
 		attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 	});
 

--- a/2026/standort/script/map1.js
+++ b/2026/standort/script/map1.js
@@ -29,7 +29,7 @@
 		className: 'svg-feature'
 	};
 
-	const baseLayer = L.tileLayer('https://{s}.tile.openstreetmap.de/{z}/{x}/{y}.png', {
+	const baseLayer = L.tileLayer('https://tile.openstreetmap.de/{z}/{x}/{y}.png', {
 		attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 	});
 


### PR DESCRIPTION
tile.openstreetmap.de [has retired their a., b. and c. aliases as of 1 August 2023](https://community.openstreetmap.org/t/a-b-c-tile-openstreetmap-de-subdomains-von-tile-openstreetmap-de-werden-aufgehoben/100830).

Feel free to modify this PR and update other maps across repositories for your organization.

---

as in https://github.com/fossgis/openstreetmap.de/pull/51